### PR TITLE
adjustment to sonar

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -79,4 +79,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          sonar-scanner --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
+          sonar-scanner --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json"


### PR DESCRIPTION
Addresses: Property 'sonar.cfamily.build-wrapper-output' is deprecated; build-wrapper now generates a compilation database.
Please use the property 'sonar.cfamily.compile-commands' instead to specify the path of the 'compile_commands.json' file generated inside the build-wrapper output directory. 
