### PR TITLE
exclude PGM C API from default build targets

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   clang-tidy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         build-option: [ debug, release ]

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   clang-tidy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         build-option: [ debug, release ]
@@ -51,10 +51,10 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build clang-15 clang-tidy-15
-          sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
-          sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
-          sudo ln -s /usr/bin/clang-tidy-15 /usr/local/bin/clang-tidy
+          sudo apt-get install -y ninja-build clang-18 clang-tidy-18
+          sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
+          sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
+          sudo ln -s /usr/bin/clang-tidy-18 /usr/local/bin/clang-tidy
 
       - name: Enable brew
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
           path: ./wheelhouse/*.tar.gz
 
   build-cpp-test-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         build-option: [ debug, release ]
@@ -86,11 +86,11 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build gcc-12 g++-12 clang-15
-          sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
-          sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
-          sudo ln -s /usr/bin/gcc-12 /usr/local/bin/gcc
-          sudo ln -s /usr/bin/g++-12 /usr/local/bin/g++
+          sudo apt-get install -y ninja-build gcc-13 g++-13 clang-18
+          sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
+          sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
+          sudo ln -s /usr/bin/gcc-13 /usr/local/bin/gcc
+          sudo ln -s /usr/bin/g++-13 /usr/local/bin/g++
 
       - name: Enable brew
         run: |

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
       CMAKE_PREFIX_PATH: /home/linuxbrew/.linuxbrew
-      LLVM_COV: llvm-cov-15
+      LLVM_COV: llvm-cov-18
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,9 +38,9 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build clang-15 lcov gcovr
-          sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
-          sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
+          sudo apt-get install -y ninja-build clang-18 lcov gcovr
+          sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
+          sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
       - name: Enable brew
         run: |
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -2,5 +2,8 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-set_directory_properties(PROPERTIES EXCLUDE_FROM_ALL TRUE)
+set_directory_properties(PROPERTIES
+    SYSTEM TRUE
+    EXCLUDE_FROM_ALL TRUE
+)
 add_subdirectory("power-grid-model")

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -2,5 +2,5 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+set_directory_properties(PROPERTIES EXCLUDE_FROM_ALL TRUE)
 add_subdirectory("power-grid-model")
-

--- a/power_grid_model_io_native_c/power_grid_model_io_native_c/include/power_grid_model_io_native_c/basics.h
+++ b/power_grid_model_io_native_c/power_grid_model_io_native_c/include/power_grid_model_io_native_c/basics.h
@@ -80,6 +80,8 @@ typedef struct PGM_IO_Handle PGM_IO_Handle;
 
 // NOLINTEND(modernize-use-using)
 
+// NOLINTBEGIN(performance-enum-size)
+
 /**
  * @brief Enumeration of error codes.
  *
@@ -104,6 +106,8 @@ enum PGM_IO_ExperimentalFeatures {
     PGM_IO_experimental_features_disabled = 0, /**< disable experimental features */
     PGM_IO_experimental_features_enabled = 1,  /**< enable experimental features */
 };
+
+// NOLINTEND(performance-enum-size)
 
 #ifdef __cplusplus
 }

--- a/power_grid_model_io_native_c/power_grid_model_io_native_c/src/handle.cpp
+++ b/power_grid_model_io_native_c/power_grid_model_io_native_c/src/handle.cpp
@@ -5,10 +5,9 @@
 #define PGM_IO_DLL_EXPORTS
 
 #include "power_grid_model_io_native_c/handle.h"
+#include "power_grid_model_io_native_c/basics.h"
 
-#include "handle.hpp"
-
-#include <algorithm>
+#include "handle.hpp" // NOLINT(misc-include-cleaner)
 
 namespace {
 using namespace power_grid_model_io_native;

--- a/power_grid_model_io_native_c/power_grid_model_io_native_c/src/pgm_vnf_converter.cpp
+++ b/power_grid_model_io_native_c/power_grid_model_io_native_c/src/pgm_vnf_converter.cpp
@@ -11,7 +11,6 @@
 #include <power_grid_model_io_native_c/basics.h>
 #include <power_grid_model_io_native_c/pgm_vnf_converter.h>
 
-#include <power_grid_model/auxiliary/dataset.hpp>
 #include <power_grid_model/common/exception.hpp>
 
 namespace pgm_io = power_grid_model_io_native;

--- a/tests/c_api_tests/test_c_api.cpp
+++ b/tests/c_api_tests/test_c_api.cpp
@@ -2,13 +2,12 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+// NOLINTBEGIN(misc-include-cleaner)
+
 #include "c_api_cpp_handle.hpp"
 #include "power_grid_model_io_native_c.h"
 
 #include <doctest/doctest.h>
-
-#include <memory>
-
 namespace power_grid_model_io_native {
 
 TEST_CASE("C API") {
@@ -19,3 +18,5 @@ TEST_CASE("C API") {
 }
 
 } // namespace power_grid_model_io_native
+
+// NOLINTEND(misc-include-cleaner)

--- a/tests/c_api_tests/test_c_api_pgm_vnf_converter.cpp
+++ b/tests/c_api_tests/test_c_api_pgm_vnf_converter.cpp
@@ -8,10 +8,9 @@
 #include <power_grid_model_io_native_c/handle.h>
 #include <power_grid_model_io_native_c/pgm_vnf_converter.h>
 
-#include <power_grid_model/common/exception.hpp>
-
-#include <cstring>
 #include <doctest/doctest.h>
+
+#include <string_view>
 
 namespace power_grid_model_io_native {
 
@@ -22,7 +21,7 @@ TEST_CASE("Test PGM_IO_create_vnf_converter") {
 
     SUBCASE("Test PGM_IO_create_vnf_converter without experimental feature flag") {
         PGM_IO_Handle* handle = PGM_IO_create_handle();
-        auto converter = PGM_IO_create_pgm_vnf_converter(handle, "", experimental_feature_flag);
+        auto* converter = PGM_IO_create_pgm_vnf_converter(handle, "", experimental_feature_flag);
         CHECK(PGM_IO_error_code(handle) == PGM_IO_regular_error);
         PGM_IO_destroy_pgm_vnf_converter(converter);
         PGM_IO_destroy_handle(handle);
@@ -31,7 +30,7 @@ TEST_CASE("Test PGM_IO_create_vnf_converter") {
     SUBCASE("Test PGM_IO_create_vnf_converter with experimental feature flag") {
         PGM_IO_Handle* handle = PGM_IO_create_handle();
         experimental_feature_flag = PGM_IO_experimental_features_enabled;
-        auto converter = PGM_IO_create_pgm_vnf_converter(handle, "", experimental_feature_flag);
+        auto* converter = PGM_IO_create_pgm_vnf_converter(handle, "", experimental_feature_flag);
         CHECK(converter != nullptr);
         PGM_IO_destroy_pgm_vnf_converter(converter);
         PGM_IO_destroy_handle(handle);
@@ -40,13 +39,14 @@ TEST_CASE("Test PGM_IO_create_vnf_converter") {
 
 TEST_CASE("Test PGM_IO_get_vnf_input_data") {
     PGM_IO_Handle* handle = PGM_IO_create_handle();
-    PGM_IO_ExperimentalFeatures experimental_feature_flag = PGM_IO_experimental_features_enabled;
+    PGM_IO_ExperimentalFeatures const experimental_feature_flag = PGM_IO_experimental_features_enabled;
 
-    auto converter = PGM_IO_create_pgm_vnf_converter(handle, "", experimental_feature_flag);
+    auto* converter = PGM_IO_create_pgm_vnf_converter(handle, "", experimental_feature_flag);
     CHECK(converter != nullptr);
 
-    auto json_result = PGM_IO_pgm_vnf_converter_get_input_data(handle, converter);
-    std::string_view json_string = R"({"version":"1.0","type":"input","is_batch":false,"attributes":{},"data":{}})";
+    auto const* const json_result = PGM_IO_pgm_vnf_converter_get_input_data(handle, converter);
+    std::string_view const json_string =
+        R"({"version":"1.0","type":"input","is_batch":false,"attributes":{},"data":{}})";
     CHECK(json_string == json_result);
 
     PGM_IO_destroy_pgm_vnf_converter(converter);

--- a/tests/c_api_tests/test_c_api_pgm_vnf_converter.cpp
+++ b/tests/c_api_tests/test_c_api_pgm_vnf_converter.cpp
@@ -2,14 +2,13 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-#
-
 #include <power_grid_model_io_native_c/basics.h>
 #include <power_grid_model_io_native_c/handle.h>
 #include <power_grid_model_io_native_c/pgm_vnf_converter.h>
 
 #include <doctest/doctest.h>
 
+#include <ostream> // NOLINT(misc-include-cleaner) // Windows Clang-Tidy issue
 #include <string_view>
 
 namespace power_grid_model_io_native {

--- a/tests/c_api_tests/test_entry_point.cpp
+++ b/tests/c_api_tests/test_entry_point.cpp
@@ -6,4 +6,4 @@
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
-#include <doctest/doctest.h>
+#include <doctest/doctest.h> // NOLINT(misc-include-cleaner)

--- a/tests/cpp_unit_tests/test_entry_point.cpp
+++ b/tests/cpp_unit_tests/test_entry_point.cpp
@@ -6,4 +6,4 @@
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
-#include <doctest/doctest.h>
+#include <doctest/doctest.h> // NOLINT(misc-include-cleaner)

--- a/tests/cpp_unit_tests/test_pgm_vnf_converter.cpp
+++ b/tests/cpp_unit_tests/test_pgm_vnf_converter.cpp
@@ -6,17 +6,19 @@
 #include <power_grid_model_io_native/pgm_vnf_converter/pgm_vnf_converter.hpp>
 
 #include <power_grid_model/auxiliary/dataset.hpp>
-#include <power_grid_model/auxiliary/meta_data.hpp>
-#include <power_grid_model/auxiliary/meta_gen/gen_getters.hpp>
+#include <power_grid_model/auxiliary/meta_data_gen.hpp>
+#include <power_grid_model/common/exception.hpp>
 
-#include <cstring>
 #include <doctest/doctest.h>
+
+#include <sstream>
+#include <string_view>
 
 namespace power_grid_model_io_native {
 
 using enum ExperimentalFeatures;
 
-std::string_view json_string = R"({"version":"1.0","type":"input","is_batch":false,"attributes":{},"data":{}})";
+std::string_view const json_string = R"({"version":"1.0","type":"input","is_batch":false,"attributes":{},"data":{}})";
 
 TEST_CASE("Test converter constructor") {
     SUBCASE("Without experimental features") {
@@ -58,7 +60,7 @@ TEST_CASE("Test serialize_data") {
 
 TEST_CASE("Test setter/getter of file_buffer") {
     auto converter = PgmVnfConverter("", experimental_features_enabled);
-    std::string_view value = "123";
+    std::string_view const value = "123";
     converter.set_file_buffer(value);
     auto file_buff = converter.get_file_buffer();
     CHECK(file_buff == value);
@@ -72,7 +74,7 @@ TEST_CASE("Test setter/getter of deserialized_data") {
 
     auto converter = PgmVnfConverter("", experimental_features_enabled);
     converter.set_deserialized_dataset(&writable_dataset);
-    auto writable_dataset_after_getter = converter.get_deserialized_dataset();
+    auto* const writable_dataset_after_getter = converter.get_deserialized_dataset();
     CHECK(&writable_dataset == writable_dataset_after_getter);
 }
 

--- a/tests/cpp_unit_tests/test_pgm_vnf_converter.cpp
+++ b/tests/cpp_unit_tests/test_pgm_vnf_converter.cpp
@@ -8,10 +8,13 @@
 #include <power_grid_model/auxiliary/dataset.hpp>
 #include <power_grid_model/auxiliary/meta_data_gen.hpp>
 #include <power_grid_model/common/exception.hpp>
+#include <power_grid_model/component/node.hpp>
+#include <power_grid_model/container.hpp>
 
 #include <doctest/doctest.h>
 
-#include <sstream>
+#include <ostream> // NOLINT(misc-include-cleaner) // Windows Clang-Tidy issue
+#include <string>
 #include <string_view>
 
 namespace power_grid_model_io_native {
@@ -44,13 +47,13 @@ TEST_CASE("Test convert_input") {
 }
 
 TEST_CASE("Test create_const_dataset_from_container is callable") {
-    power_grid_model::Container<power_grid_model::Node> container;
+    power_grid_model::Container<power_grid_model::Node> const container{};
     constexpr const auto& meta_data = power_grid_model::meta_data::meta_data_gen::meta_data;
     CHECK_NOTHROW(create_const_dataset_from_container(container, meta_data));
 }
 
 TEST_CASE("Test serialize_data") {
-    power_grid_model::Container<power_grid_model::Node> container;
+    power_grid_model::Container<power_grid_model::Node> const container{};
     constexpr const auto& meta_data = power_grid_model::meta_data::meta_data_gen::meta_data;
     power_grid_model::ConstDataset const const_dataset = create_const_dataset_from_container(container, meta_data);
     CHECK_NOTHROW(serialize_data(const_dataset));


### PR DESCRIPTION
The build is unnecessarily slow because it tries to build the entire PGM.