### PR TITLE
libboost-headers from pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires = [
     "pybuild-header-dependency",
     "msgpack-cxx",
     "nlohmann-json",
+    "libboost-headers",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,11 @@ def get_required_dependency_include() -> list[str]:
         either empty list or a list of header path
     """
     try:
+        import libboost_headers
         import msgpack_cxx
         import nlohmann_json
 
-        return [str(msgpack_cxx.get_include()), str(nlohmann_json.get_include())]
+        return [str(msgpack_cxx.get_include()), str(nlohmann_json.get_include()), str(libboost_headers.get_include())]
     except ImportError:
         return []
 
@@ -51,7 +52,6 @@ def get_pre_installed_header_include() -> list[str]:
         resolver = HeaderResolver(
             {
                 "eigen": None,
-                "boost": None,
             }
         )
         return [str(resolver.get_include())]


### PR DESCRIPTION
Use https://pypi.org/project/libboost-headers/ uploaded by https://github.com/PowerGridModel/boost-pypi

Cfr. https://github.com/PowerGridModel/power-grid-model/pull/856
